### PR TITLE
Add category management to admin questions workflow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import {
   auth,
   db,
@@ -64,7 +64,7 @@ export default function App() {
   }
 
   return (
-    <BrowserRouter>
+    <>
       <Header user={user} isAdmin={isAdmin} />
       <div className="min-h-screen bg-gradient-to-br from-indigo-50 to-purple-100 p-4">
         <Routes>
@@ -79,6 +79,6 @@ export default function App() {
           <Route path="*" element={<HomePage user={user} />} />
         </Routes>
       </div>
-    </BrowserRouter>
+    </>
   );
 }

--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -25,22 +25,51 @@ export default function AdminDashboard({ user }) {
     return <div className="p-6">Access denied. You are not an administrator.</div>;
   }
   return (
-    <div className="p-6 space-y-4">
-      <h1 className="text-2xl font-semibold">Admin Panel</h1>
-      <div className="flex space-x-4">
-        {['questions', 'exams', 'progress'].map((t) => (
-          <button
-            key={t}
-            onClick={() => setTab(t)}
-            className={`${tab === t ? 'bg-primary text-white' : 'bg-gray-200'} px-4 py-2 rounded`}
-          >
-            {t.charAt(0).toUpperCase() + t.slice(1)}
-          </button>
-        ))}
+    <div className="min-h-screen bg-slate-100 py-10">
+      <div className="max-w-6xl mx-auto px-4 space-y-8">
+        <header className="space-y-2">
+          <p className="text-sm uppercase tracking-wide text-slate-500">Administration</p>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h1 className="text-3xl font-semibold text-slate-900">Admin Control Center</h1>
+              <p className="text-slate-600">
+                Manage categories, questions, exams, and review learner progress from one place.
+              </p>
+            </div>
+            <div className="flex items-center space-x-2 text-sm text-slate-500">
+              <span className="inline-flex h-2 w-2 rounded-full bg-emerald-500"></span>
+              <span>Signed in as {user.name || user.email}</span>
+            </div>
+          </div>
+        </header>
+        <div className="bg-white shadow-sm rounded-2xl p-4 sm:p-6">
+          <nav className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap gap-2">
+              {['questions', 'exams', 'progress'].map((t) => {
+                const active = tab === t;
+                return (
+                  <button
+                    key={t}
+                    onClick={() => setTab(t)}
+                    className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                      active
+                        ? 'bg-primary text-white shadow'
+                        : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                    }`}
+                  >
+                    {t.charAt(0).toUpperCase() + t.slice(1)}
+                  </button>
+                );
+              })}
+            </div>
+          </nav>
+          <div className="mt-6">
+            {tab === 'questions' && <ManageQuestions />}
+            {tab === 'exams' && <ManageExams />}
+            {tab === 'progress' && <ViewProgress />}
+          </div>
+        </div>
       </div>
-      {tab === 'questions' && <ManageQuestions />}
-      {tab === 'exams' && <ManageExams />}
-      {tab === 'progress' && <ViewProgress />}
     </div>
   );
 }
@@ -51,22 +80,48 @@ function ManageQuestions() {
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editQuestion, setEditQuestion] = useState(null);
+  const [categories, setCategories] = useState([]);
+  const [categoryLoading, setCategoryLoading] = useState(true);
+  const [importCategoryId, setImportCategoryId] = useState('');
   const fileInputRef = useRef(null);
 
   useEffect(() => {
-    async function fetchQuestions() {
+    async function fetchData() {
       try {
-        const snap = await getDocs(collection(db, 'questions'));
-        const list = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
-        setQuestions(list);
+        const [questionSnap, categorySnap] = await Promise.all([
+          getDocs(collection(db, 'questions')),
+          getDocs(collection(db, 'categories')),
+        ]);
+        const fetchedQuestions = questionSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        const fetchedCategories = categorySnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        setQuestions(fetchedQuestions);
+        setCategories(fetchedCategories);
       } catch (err) {
-        console.error('Failed to fetch questions', err);
+        console.error('Failed to fetch admin data', err);
       } finally {
         setLoading(false);
+        setCategoryLoading(false);
       }
     }
-    fetchQuestions();
+    fetchData();
   }, []);
+
+  const handleCategoryCreated = (category) => {
+    setCategories((prev) => [...prev, category]);
+  };
+
+  const handleCategoryDeleted = (categoryId) => {
+    setCategories((prev) => prev.filter((c) => c.id !== categoryId));
+    // Remove category reference from local questions to keep UI consistent
+    setQuestions((prev) =>
+      prev.map((question) =>
+        question.categoryId === categoryId
+          ? { ...question, categoryId: null, categoryName: 'Unassigned' }
+          : question,
+      ),
+    );
+    setImportCategoryId((prev) => (prev === categoryId ? '' : prev));
+  };
 
   const handleDelete = async (qid) => {
     if (!confirm('Delete this question?')) return;
@@ -81,6 +136,17 @@ function ManageQuestions() {
   const handleImportFile = async (e) => {
     const file = e.target.files[0];
     if (!file) return;
+    if (!importCategoryId) {
+      alert('Please choose a category for the imported questions first.');
+      e.target.value = '';
+      return;
+    }
+    const selectedCategory = categories.find((cat) => cat.id === importCategoryId);
+    if (!selectedCategory) {
+      alert('Selected category no longer exists.');
+      e.target.value = '';
+      return;
+    }
     try {
       const text = await file.text();
       const json = JSON.parse(text);
@@ -90,8 +156,14 @@ function ManageQuestions() {
       }
       for (const item of json) {
         if (!item.text || !item.type) continue;
-        const ref = await addDoc(collection(db, 'questions'), item);
-        setQuestions((prev) => [...prev, { id: ref.id, ...item }]);
+        const payload = {
+          ...item,
+          categoryId: selectedCategory.id,
+          categoryName: selectedCategory.name,
+          category: selectedCategory.name,
+        };
+        const ref = await addDoc(collection(db, 'questions'), payload);
+        setQuestions((prev) => [...prev, { id: ref.id, ...payload }]);
       }
       alert('Questions imported successfully');
     } catch (err) {
@@ -132,90 +204,179 @@ function ManageQuestions() {
     return <div className="p-4">Loading questions…</div>;
   }
   return (
-    <div className="space-y-4">
-      <div className="flex space-x-4">
-        <button
-          onClick={() => {
-            setShowForm(true);
-            setEditQuestion(null);
-          }}
-          className="bg-primary text-white px-3 py-2 rounded"
-        >
-          Add Question
-        </button>
-        <button onClick={handleExport} className="bg-blue-600 text-white px-3 py-2 rounded">
-          Export JSON
-        </button>
-        <button
-          onClick={() => fileInputRef.current?.click()}
-          className="bg-green-600 text-white px-3 py-2 rounded"
-        >
-          Import JSON
-        </button>
-        <input
-          type="file"
-          accept=".json,application/json"
-          ref={fileInputRef}
-          onChange={handleImportFile}
-          className="hidden"
-        />
+    <div className="grid gap-6 lg:grid-cols-[320px,1fr]">
+      <CategoryManager
+        categories={categories}
+        loading={categoryLoading}
+        onCreated={handleCategoryCreated}
+        onDeleted={handleCategoryDeleted}
+      />
+      <div className="space-y-6">
+        <div className="bg-slate-900 text-white rounded-2xl p-6 shadow-sm">
+          <h2 className="text-xl font-semibold">Questions workspace</h2>
+          <p className="mt-1 text-sm text-slate-200">
+            Build your question bank once categories are in place. Import, edit or export items with
+            a few clicks.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <button
+              onClick={() => {
+                setShowForm(true);
+                setEditQuestion(null);
+              }}
+              disabled={!categories.length}
+              className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                categories.length
+                  ? 'bg-white text-slate-900 hover:bg-slate-200'
+                  : 'bg-slate-700 text-slate-400 cursor-not-allowed'
+              }`}
+            >
+              Add Question
+            </button>
+            <button
+              onClick={handleExport}
+              className="rounded-full px-4 py-2 text-sm font-medium bg-slate-100 text-slate-900 hover:bg-slate-200"
+            >
+              Export JSON
+            </button>
+            <div className="flex flex-wrap gap-2 items-center text-sm">
+              <label className="text-slate-300">Import to category</label>
+              <select
+                value={importCategoryId}
+                onChange={(e) => setImportCategoryId(e.target.value)}
+                className="rounded-full bg-white/10 border border-white/20 px-3 py-1 text-white"
+              >
+                <option value="">Select…</option>
+                {categories.map((cat) => (
+                  <option key={cat.id} value={cat.id} className="text-slate-900">
+                    {cat.name}
+                  </option>
+                ))}
+              </select>
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                disabled={!categories.length}
+                className={`rounded-full px-4 py-2 font-medium transition ${
+                  categories.length
+                    ? 'bg-emerald-500 text-slate-900 hover:bg-emerald-400'
+                    : 'bg-slate-700 text-slate-400 cursor-not-allowed'
+                }`}
+              >
+                Import JSON
+              </button>
+            </div>
+            <input
+              type="file"
+              accept=".json,application/json"
+              ref={fileInputRef}
+              onChange={handleImportFile}
+              className="hidden"
+            />
+          </div>
+          {!categories.length && !categoryLoading && (
+            <p className="mt-3 text-sm text-amber-200">
+              Create at least one category before adding or importing questions.
+            </p>
+          )}
+        </div>
+
+        {showForm && (
+          <QuestionForm
+            initial={editQuestion}
+            categories={categories}
+            onClose={handleFormClose}
+            onSave={handleSave}
+          />
+        )}
+
+        <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+          <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900">Question bank</h3>
+              <p className="text-sm text-slate-500">{questions.length} questions available.</p>
+            </div>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-left text-sm">
+              <thead className="bg-slate-50 text-slate-600 uppercase text-xs tracking-wide">
+                <tr>
+                  <th className="px-6 py-3 font-semibold">Question</th>
+                  <th className="px-6 py-3 font-semibold">Type</th>
+                  <th className="px-6 py-3 font-semibold">Category</th>
+                  <th className="px-6 py-3 font-semibold text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {questions.map((q) => (
+                  <tr key={q.id} className="hover:bg-slate-50">
+                    <td className="px-6 py-4 text-slate-700">{q.text}</td>
+                    <td className="px-6 py-4 capitalize text-slate-500">{q.type}</td>
+                    <td className="px-6 py-4 text-slate-600">
+                      {q.categoryName || q.category || 'Unassigned'}
+                    </td>
+                    <td className="px-6 py-4 text-right space-x-3">
+                      <button
+                        onClick={() => {
+                          setEditQuestion(q);
+                          setShowForm(true);
+                        }}
+                        className="text-primary font-medium hover:underline"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => handleDelete(q.id)}
+                        className="text-rose-500 font-medium hover:underline"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+                {!questions.length && !loading && (
+                  <tr>
+                    <td className="px-6 py-8 text-center text-slate-500" colSpan={4}>
+                      No questions yet. Create one once categories are available.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+          {loading && (
+            <div className="px-6 py-4 text-sm text-slate-500">Loading questions…</div>
+          )}
+        </div>
       </div>
-      {showForm && (
-        <QuestionForm
-          initial={editQuestion}
-          onClose={handleFormClose}
-          onSave={handleSave}
-        />
-      )}
-      <table className="w-full table-auto border-collapse">
-        <thead>
-          <tr>
-            <th className="border px-2 py-1">Text</th>
-            <th className="border px-2 py-1">Type</th>
-            <th className="border px-2 py-1">Category</th>
-            <th className="border px-2 py-1">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {questions.map((q) => (
-            <tr key={q.id}>
-              <td className="border px-2 py-1">{q.text}</td>
-              <td className="border px-2 py-1 capitalize">{q.type}</td>
-              <td className="border px-2 py-1">{q.category || '-'}</td>
-              <td className="border px-2 py-1 space-x-2">
-                <button
-                  onClick={() => {
-                    setEditQuestion(q);
-                    setShowForm(true);
-                  }}
-                  className="text-blue-600 underline"
-                >
-                  Edit
-                </button>
-                <button
-                  onClick={() => handleDelete(q.id)}
-                  className="text-red-600 underline"
-                >
-                  Delete
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
     </div>
   );
 }
 
 // Form for creating or editing a question
-function QuestionForm({ initial, onClose, onSave }) {
+function QuestionForm({ initial, categories, onClose, onSave }) {
   const isEdit = Boolean(initial);
   const [text, setText] = useState(initial?.text || '');
   const [type, setType] = useState(initial?.type || 'mcq');
   const [optionsStr, setOptionsStr] = useState((initial?.options || []).join('\n'));
   const [answer, setAnswer] = useState(initial?.answer || '');
   const [explanation, setExplanation] = useState(initial?.explanation || '');
-  const [category, setCategory] = useState(initial?.category || '');
+  const initialCategoryId = (() => {
+    if (initial?.categoryId) return initial.categoryId;
+    if (initial?.category) {
+      const matched = categories.find(
+        (cat) => cat.name.toLowerCase() === initial.category.toLowerCase(),
+      );
+      if (matched) return matched.id;
+    }
+    if (initial?.categoryName) {
+      const matched = categories.find(
+        (cat) => cat.name.toLowerCase() === initial.categoryName.toLowerCase(),
+      );
+      if (matched) return matched.id;
+    }
+    return '';
+  })();
+  const [categoryId, setCategoryId] = useState(initialCategoryId);
   const [saving, setSaving] = useState(false);
 
   const handleSubmit = async (e) => {
@@ -226,8 +387,16 @@ function QuestionForm({ initial, onClose, onSave }) {
         text: text,
         type: type,
         explanation: explanation,
-        category: category,
       };
+      const selectedCategory = categories.find((cat) => cat.id === categoryId);
+      if (selectedCategory) {
+        data.categoryId = selectedCategory.id;
+        data.categoryName = selectedCategory.name;
+        data.category = selectedCategory.name;
+      } else {
+        data.categoryId = null;
+        data.categoryName = 'Unassigned';
+      }
       if (type === 'mcq' || type === 'drag') {
         const opts = optionsStr
           .split('\n')
@@ -344,13 +513,21 @@ function QuestionForm({ initial, onClose, onSave }) {
         )}
         <div>
           <label className="block font-medium">Category</label>
-          <input
-            type="text"
-            value={category}
-            onChange={(e) => setCategory(e.target.value)}
+          <select
+            value={categoryId}
+            onChange={(e) => setCategoryId(e.target.value)}
+            required
             className="w-full border rounded p-2"
-            placeholder="Enter category (e.g. Algebra, Grammar…)"
-          />
+          >
+            <option value="" disabled>
+              Select a category
+            </option>
+            {categories.map((cat) => (
+              <option key={cat.id} value={cat.id}>
+                {cat.name}
+              </option>
+            ))}
+          </select>
         </div>
         <div>
           <label className="block font-medium">Explanation (optional)</label>
@@ -380,6 +557,129 @@ function QuestionForm({ initial, onClose, onSave }) {
         </div>
       </form>
     </div>
+  );
+}
+
+function CategoryManager({ categories, loading, onCreated, onDeleted }) {
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setSaving(true);
+    try {
+      const payload = {
+        name: name.trim(),
+        description: description.trim(),
+        createdAt: Date.now(),
+      };
+      const ref = await addDoc(collection(db, 'categories'), payload);
+      onCreated({ id: ref.id, ...payload });
+      setName('');
+      setDescription('');
+      setShowForm(false);
+    } catch (err) {
+      console.error('Failed to create category', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm('Delete this category? Questions linked to it will show as Unassigned.')) return;
+    try {
+      await deleteDoc(doc(db, 'categories', id));
+      onDeleted(id);
+    } catch (err) {
+      console.error('Failed to delete category', err);
+    }
+  };
+
+  return (
+    <aside className="bg-white rounded-2xl shadow-sm p-6 space-y-5 self-start">
+      <div>
+        <h2 className="text-lg font-semibold text-slate-900">Categories</h2>
+        <p className="text-sm text-slate-500">
+          Organise the question bank with dedicated categories. Add categories before creating
+          questions.
+        </p>
+      </div>
+      <button
+        onClick={() => setShowForm((prev) => !prev)}
+        className="w-full rounded-full bg-primary text-white py-2 font-medium hover:opacity-90 transition"
+      >
+        {showForm ? 'Close form' : 'New category'}
+      </button>
+      {showForm && (
+        <form onSubmit={handleSubmit} className="space-y-3 border border-slate-200 rounded-xl p-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-700">Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              className="mt-1 w-full rounded border border-slate-300 px-3 py-2"
+              placeholder="e.g. Algebra"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700">Description</label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              className="mt-1 w-full rounded border border-slate-300 px-3 py-2"
+              placeholder="Optional context for this category"
+            ></textarea>
+          </div>
+          <button
+            type="submit"
+            disabled={saving}
+            className="w-full rounded-full bg-emerald-500 text-slate-900 py-2 font-semibold hover:bg-emerald-400 transition"
+          >
+            {saving ? 'Saving…' : 'Create category'}
+          </button>
+        </form>
+      )}
+      <div className="space-y-3">
+        <h3 className="text-xs font-semibold tracking-wide text-slate-500 uppercase">
+          Existing categories
+        </h3>
+        {loading ? (
+          <p className="text-sm text-slate-500">Loading…</p>
+        ) : categories.length ? (
+          <ul className="space-y-3">
+            {categories.map((cat) => (
+              <li
+                key={cat.id}
+                className="rounded-xl border border-slate-200 p-3 flex flex-col gap-1"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-slate-800">{cat.name}</span>
+                  <button
+                    onClick={() => handleDelete(cat.id)}
+                    className="text-xs font-semibold uppercase text-rose-500 hover:underline"
+                  >
+                    Remove
+                  </button>
+                </div>
+                {cat.description && (
+                  <p className="text-xs text-slate-500">{cat.description}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-slate-500">
+            No categories yet. Start by creating your first category.
+          </p>
+        )}
+      </div>
+    </aside>
   );
 }
 


### PR DESCRIPTION
## Summary
- redesign the admin dashboard shell with a dedicated hero header and pill navigation
- add a category manager sidebar and require selecting an existing category when adding or importing questions
- refresh the questions workspace styling and ensure question records keep their category metadata in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de547475888328a18d0b1eec791b73